### PR TITLE
Skip github.js while hotpatching

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -845,7 +845,7 @@ Chat.loadCommands = function () {
 	Object.assign(commands, require('./chat-plugins/info').commands);
 
 	for (let file of fs.readdirSync(path.resolve(__dirname, 'chat-plugins'))) {
-		if (file.substr(-3) !== '.js' || file === 'info.js') continue;
+		if (file.substr(-3) !== '.js' || file === 'info.js' || file === 'github.js') continue;
 		Object.assign(commands, require('./chat-plugins/' + file).commands);
 	}
 };

--- a/chat.js
+++ b/chat.js
@@ -843,9 +843,11 @@ Chat.loadCommands = function () {
 
 	// info always goes first so other plugins can shadow it
 	Object.assign(commands, require('./chat-plugins/info').commands);
+	
+	const skippedFiles = ['info.js', 'github.js'];
 
 	for (let file of fs.readdirSync(path.resolve(__dirname, 'chat-plugins'))) {
-		if (file.substr(-3) !== '.js' || file === 'info.js' || file === 'github.js') continue;
+		if (file.substr(-3) !== '.js' || skippedFiles.includes(file)) continue;
 		Object.assign(commands, require('./chat-plugins/' + file).commands);
 	}
 };


### PR DESCRIPTION
If we do not skip github.js there will be a crash as it will try to start the githubhook server on the same port on which it was running (say 3420) this will skip github.js when using /hotpatch chat